### PR TITLE
Fix incorrect port string char array length.

### DIFF
--- a/mcping.c
+++ b/mcping.c
@@ -78,7 +78,7 @@ int read_varint(const int sfd) {
 
 int main(int argc, char **argv) {
   unsigned short port;
-  char port_str[5];
+  char port_str[6];
   struct addrinfo hints;
   struct addrinfo *result, *rp;
   int sfd, s, json_len;


### PR DESCRIPTION
The largest possible port is 65535. This is 5 character long, but the code
did not respect the NULL byte at the end of the string.